### PR TITLE
Use packages instead of py_modules.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,17 @@
 from distutils.core import setup
 
 setup(name           = 'gzippy',
-    version          = '0.1.1',
+    version          = '0.1.2',
     description      = 'Gzip file utility.',
     url              = 'http://github.com/seomoz/gzippy',
     author           = 'Dan Lecocq',
     author_email     = 'dan@moz.com',
-    py_modules = [
+    packages = [
         'gzippy'
     ],
+    package_dir = {
+        'gzippy': 'gzippy'
+    },
     install_requires = [
     ],
     tests_require    = [


### PR DESCRIPTION
At one point, I had this set up as a module, but switched it to a package. Whoops. Forgot to update the setup.

@b4hand @sistawendy 